### PR TITLE
Force square ratio for mixtape artwork

### DIFF
--- a/src/views/components/ArticleCard.js
+++ b/src/views/components/ArticleCard.js
@@ -97,7 +97,7 @@ const ArticleCard = ({ post, ...props }) => {
         <StyledBadge bg={category.colour} colour="white">
           {category.label}
         </StyledBadge>
-        <Image fluid={image.childImageSharp.fluid} />
+        <Image fluid={{ ...image.childImageSharp.fluid, aspectRatio: 1 }} />
         <Card.Overlay
           force={isPlaying || isMouseOver || pageWidth <= Breakpoints.SM}
         >


### PR DESCRIPTION
This is a quick fix to enforce consistent mixtape artwork ratios. Motivated by the need (lol) to align the artwork of the first row of the mixtape `.masonry-container` div. 

⚠️ This assumes that all mixtape artwork will be a square!