### PR TITLE
Clicking PlayerMeta now navigates user to media page.

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -68,7 +68,6 @@ exports.createPages = async ({ graphql, actions }) => {
         }
       } = post;
       const { slug } = post.fields;
-      console.log(slug);
       const component = getPostTemplate(categoryId);
       createPage({
         path: slug,

--- a/src/components/ArticleCard.js
+++ b/src/components/ArticleCard.js
@@ -48,7 +48,8 @@ const ArticleCard = ({ post, ...props }) => {
   const cardRef = useRef(null);
   const linkRef = useRef(null);
 
-  const { frontmatter } = post;
+  const { fields, frontmatter } = post;
+  const { slug: href } = fields;
   const {
     category,
     description,
@@ -69,6 +70,7 @@ const ArticleCard = ({ post, ...props }) => {
             artist: track.user.username,
             cover: image.childImageSharp.fluid.src,
             duration: track.duration,
+            href,
             title
           }
         : null,

--- a/src/components/CoverImage.js
+++ b/src/components/CoverImage.js
@@ -5,7 +5,7 @@ import get from 'lodash.get';
 import Image from 'gatsby-image';
 import { Badge } from 'theme';
 
-import { PlayerIcon } from './player';
+import PlayerIcon from './player/PlayerIcon';
 
 const transitionTimingFn = 'cubic-bezier(0.175, 0.885, 0.32, 1.275)';
 

--- a/src/components/player/Player.js
+++ b/src/components/player/Player.js
@@ -1,123 +1,69 @@
 import React from 'react';
-import { useSelector } from 'react-redux';
 import styled from '@emotion/styled';
 import css from '@styled-system/css';
 import { PlayerStatus } from 'modules/player/constants';
 import { useListen } from 'modules/player/hooks';
-import {
-  selectPlayerMeta,
-  selectPlayerSrc,
-  selectPlayerStatus
-} from 'modules/player/selectors';
-import { Text } from 'theme';
-import DefaultCover from 'static/images/default.png';
+import { usePlayerMeta, usePlayerSrc, usePlayerStatus } from 'modules/player';
 
-import { PlayerIcon } from './PlayerIcon';
-import { PlayerProgress } from './PlayerProgress';
+import PlayerIcon from './PlayerIcon';
+import PlayerMeta from './PlayerMeta';
+import PlayerProgress from './PlayerProgress';
 import VolumeControl from './VolumeControl';
 
 const { BUFFERING } = PlayerStatus;
 
-const PlayerContainer = styled('div')(({ isVisible = false }) =>
-  css({
-    bg: 'bg',
-    display: 'flex',
-    alignItems: 'center',
-    flexDirection: ['row-reverse', 'row'],
-    justifyContent: 'space-between',
-    height: 53,
-    position: 'fixed',
-    right: 0,
-    bottom: ['calc(60px + env(safe-area-inset-bottom))', 0],
-    left: 0,
-    px: [0, 4],
-    py: [0, 2],
-    borderTop: 'container',
-    opacity: isVisible ? 1 : 0,
-    transform: isVisible ? 'translateY(0)' : 'translateY(100%)',
-    transition: 'transform 150ms ease-out, opacity 150ms ease-out',
-    width: '100%',
-    zIndex: 2
-  })
-);
-
-const MetaContainer = styled('div')(
-  css({
-    display: 'flex',
-    height: '100%',
-    minWidth: [null, 300],
-    ml: [0, 3],
-    position: ['absolute', 'relative'],
-    left: 0,
-    right: 0,
-    bottom: 0
-  })
-);
-
-const MetaImage = styled('img')(
-  css({
-    height: '100%',
-    mr: [2, 3]
-  })
-);
-
-const MetaContent = styled('div')(
-  css({
-    display: 'flex',
-    flexDirection: 'column',
-    justifyContent: 'center',
-    pb: [1, 0]
-  })
-);
-
-const MetaTitle = styled(Text)(
-  css({
-    fontWeight: 'bold',
-    lineHeight: 1.25,
-    p: 0,
-    whiteSpace: 'nowrap'
-  })
-);
-
-const MetaArtist = styled(Text)(
-  css({
-    p: 0,
-    fontSize: 2,
-    whiteSpace: 'nowrap'
-  })
-);
+const PlayerContainer = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 53px;
+  position: fixed;
+  right: 0;
+  left: 0;
+  transition: transform 150ms ease-out, opacity 150ms ease-out;
+  width: 100%;
+  z-index: 2;
+  ${({ isVisible = false }) =>
+    css({
+      bg: 'bg',
+      flexDirection: ['row-reverse', 'row'],
+      bottom: ['calc(60px + env(safe-area-inset-bottom))', 0],
+      px: [0, 4],
+      py: [0, 2],
+      borderTop: 'container',
+      opacity: isVisible ? 1 : 0,
+      transform: isVisible ? 'translateY(0)' : 'translateY(100%)'
+    })}
+`;
 
 // TODO: Dark mode fix for gradient.
-const PlayerIconContainer = styled('div')(
-  css({
+const PlayerIconContainer = styled('div')`
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1;
+  ${css({
     background: [
       'linear-gradient(90deg, rgba(255,255,255,0) 0%, rgba(255,255,255,1) 20%, rgba(255,255,255,1) 100%)',
       null
     ],
-    height: '100%',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    px: 4,
-    zIndex: 1
-  })
-);
+    px: 4
+  })}
+`;
 
 const StyledVolumeControl = styled(VolumeControl)`
   ${css({ mx: 3 })}
 `;
 
 export const Player = () => {
-  const meta = useSelector(selectPlayerMeta);
-  const src = useSelector(selectPlayerSrc);
-  const status = useSelector(selectPlayerStatus);
+  const meta = usePlayerMeta();
+  const src = usePlayerSrc();
+  const status = usePlayerStatus();
 
-  const listenFn = useListen(src, meta);
-
-  const { artist, cover, title } = meta;
   const isVisible = status >= BUFFERING || false;
-
-  const onClick = () => listenFn();
+  const listen = useListen(src, meta);
+  const onClick = () => listen();
 
   return (
     <PlayerContainer isVisible={isVisible}>
@@ -126,13 +72,7 @@ export const Player = () => {
       </PlayerIconContainer>
       <PlayerProgress />
       <StyledVolumeControl />
-      <MetaContainer>
-        <MetaImage src={cover || DefaultCover} />
-        <MetaContent>
-          <MetaTitle>{title}</MetaTitle>
-          <MetaArtist>{artist}</MetaArtist>
-        </MetaContent>
-      </MetaContainer>
+      <PlayerMeta />
     </PlayerContainer>
   );
 };

--- a/src/components/player/PlayerIcon.js
+++ b/src/components/player/PlayerIcon.js
@@ -17,13 +17,7 @@ const StyledPlayerIcon = styled(Box)(
   })
 );
 
-export function PlayerIcon({
-  color = 'white',
-  onClick,
-  size,
-  src = null,
-  ...props
-}) {
+function PlayerIcon({ color = 'white', onClick, size, src = null, ...props }) {
   const isSelected = useIsListening(src);
   const playerStatus = usePlayerStatus();
   const renderIcon = () => {
@@ -39,3 +33,5 @@ export function PlayerIcon({
   };
   return <StyledPlayerIcon {...props}>{renderIcon()}</StyledPlayerIcon>;
 }
+
+export default PlayerIcon;

--- a/src/components/player/PlayerMeta.js
+++ b/src/components/player/PlayerMeta.js
@@ -1,0 +1,75 @@
+import React from 'react';
+import { navigate } from 'gatsby';
+import styled from '@emotion/styled';
+import css from '@styled-system/css';
+import { usePlayerMeta } from 'modules/player';
+import { Text } from 'theme';
+import DefaultCover from 'static/images/default.png';
+
+const MetaContainer = styled('div')`
+  cursor: pointer;
+  display: flex;
+  height: 100%;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  ${css({
+    minWidth: [null, 300],
+    ml: [0, 3],
+    position: ['absolute', 'relative']
+  })}
+  & > * {
+    user-select: none;
+  }
+`;
+
+const MetaImage = styled('img')`
+  height: 100%;
+  ${css({
+    mr: [2, 3]
+  })}
+`;
+
+const MetaContent = styled('div')`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  ${css({
+    pb: [1, 0]
+  })}
+`;
+
+const MetaTitle = styled(Text)`
+  font-weight: bold;
+  white-space: nowrap;
+  line-height: 1.25em;
+  ${css({ p: 0 })}
+`;
+
+const MetaArtist = styled(Text)`
+  white-space: nowrap;
+  ${css({
+    p: 0,
+    fontSize: 2
+  })}
+`;
+
+function PlayerMeta() {
+  const { artist, cover, title, href = null } = usePlayerMeta();
+
+  const onClick = () => {
+    if (href) navigate(href);
+  };
+
+  return (
+    <MetaContainer onClick={onClick}>
+      <MetaImage src={cover || DefaultCover} />
+      <MetaContent>
+        <MetaTitle>{title}</MetaTitle>
+        <MetaArtist>{artist}</MetaArtist>
+      </MetaContent>
+    </MetaContainer>
+  );
+}
+
+export default PlayerMeta;

--- a/src/components/player/PlayerProgress.js
+++ b/src/components/player/PlayerProgress.js
@@ -53,7 +53,7 @@ const PlayerProgressText = styled(Text)`
     })}
 `;
 
-export function PlayerProgress({ ...props }) {
+function PlayerProgress({ ...props }) {
   const { duration = 0 } = usePlayerMeta();
   const playerProgress = usePlayerProgress();
   const playerStatus = usePlayerStatus();
@@ -74,3 +74,5 @@ export function PlayerProgress({ ...props }) {
     </PlayerProgressContainer>
   );
 }
+
+export default PlayerProgress;

--- a/src/components/player/index.js
+++ b/src/components/player/index.js
@@ -1,2 +1,1 @@
 export * from './Player';
-export * from './PlayerIcon';

--- a/src/components/templates/Mixtape.js
+++ b/src/components/templates/Mixtape.js
@@ -25,7 +25,7 @@ import {
 import { CoverImage } from '../CoverImage';
 import { Tracklist } from '../Tracklist';
 import { Page } from '../layout';
-import { PlayerIcon } from '../player';
+import PlayerIcon from '../player/PlayerIcon';
 
 const MixtapeImageContainer = styled.div`
   position: relative;
@@ -106,6 +106,7 @@ const MixtapeTemplate = ({ data }) => {
   const post = get(data, 'markdownRemark', null);
 
   const { fields, frontmatter, html } = post;
+  const { slug: href } = fields;
   const {
     category,
     date,
@@ -126,6 +127,7 @@ const MixtapeTemplate = ({ data }) => {
             artist: track.user.username,
             cover: image.childImageSharp.fluid.src,
             duration: track.duration,
+            href,
             title
           }
         : null,
@@ -160,7 +162,7 @@ const MixtapeTemplate = ({ data }) => {
       description={description}
       title={title}
       image={imageSrc}
-      slug={fields.slug}
+      slug={href}
       type="article"
     >
       <Box width={[1, 1, 3 / 5]}>

--- a/src/modules/player/hooks/index.js
+++ b/src/modules/player/hooks/index.js
@@ -3,5 +3,6 @@ export * from './useIsPlaying';
 export * from './useListen';
 export * from './usePlayerMeta';
 export * from './usePlayerProgress';
+export * from './usePlayerSrc';
 export * from './usePlayerStatus';
 export * from './usePlayerVolume';

--- a/src/modules/player/hooks/usePlayerSrc.js
+++ b/src/modules/player/hooks/usePlayerSrc.js
@@ -1,0 +1,9 @@
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+
+import { selectPlayerSrc } from '../selectors';
+
+export const usePlayerSrc = () => {
+  const playerSrc = useSelector(selectPlayerSrc);
+  return useMemo(() => playerSrc, [playerSrc]);
+};

--- a/src/modules/radio/hooks/usePlayRadio.js
+++ b/src/modules/radio/hooks/usePlayRadio.js
@@ -1,12 +1,12 @@
-import { useSelector } from 'react-redux';
 import { useListen, PauseAction } from 'modules/player';
 import { RadioUrl } from '../constants';
-import { selectRadioMeta } from '../selectors';
+import { useRadioMeta } from './useRadioMeta';
 
 /**
  * Returns a function that starts or stops the radio stream.
  */
 export const usePlayRadio = () => {
-  const meta = useSelector(selectRadioMeta);
-  return useListen(RadioUrl, meta, PauseAction.STOP);
+  const radioMeta = useRadioMeta();
+  const radioMetaWithHref = { ...radioMeta, href: '/' };
+  return useListen(RadioUrl, radioMetaWithHref, PauseAction.STOP);
 };


### PR DESCRIPTION
Closes #61.

Changelog
---
- Clicking the player artwork when the live stream is playing should redirect the listener to the homepage ("Live").
- Clicking the player artwork when a mixtape is playing should redirect the listener to the mixtape page.
